### PR TITLE
✨ Feature | Add create training use case (#2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/squillteam/powerflix-backend
 
 go 1.22
+
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/application/port/input/training_usecase.go
+++ b/internal/application/port/input/training_usecase.go
@@ -5,12 +5,15 @@ import (
 )
 
 type TrainingInput struct {
-	ID          string
 	Name        string
 	Description string
 	Cover       string
 }
 
 type GetAllTrainingUseCase interface {
-	Execute() ([]entity.Training, error)
+	Execute() ([]*entity.Training, error)
+}
+
+type CreateTrainingUseCase interface {
+	Execute(trainingInput *TrainingInput) (*entity.Training, error)
 }

--- a/internal/application/port/output/training_repository.go
+++ b/internal/application/port/output/training_repository.go
@@ -5,5 +5,6 @@ import (
 )
 
 type TrainingRepository interface {
-	GetAllTraining() ([]entity.Training, error)
+	GetAll() ([]*entity.Training, error)
+	Save(*entity.Training) (*entity.Training, error)
 }

--- a/internal/application/usecase/create_training_usecase.go
+++ b/internal/application/usecase/create_training_usecase.go
@@ -1,0 +1,35 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/squillteam/powerflix-backend/internal/application/port/input"
+	"github.com/squillteam/powerflix-backend/internal/application/port/output"
+	"github.com/squillteam/powerflix-backend/internal/domain/entity"
+)
+
+type createTrainingUseCase struct {
+	trainingRepository output.TrainingRepository
+}
+
+func NewCreateTrainingUseCase(trainingRepository output.TrainingRepository) input.CreateTrainingUseCase {
+	return &createTrainingUseCase{
+		trainingRepository: trainingRepository,
+	}
+}
+
+func (c createTrainingUseCase) Execute(trainingInput *input.TrainingInput) (*entity.Training, error) {
+	training, err := entity.NewTraining(trainingInput.Name, trainingInput.Description, trainingInput.Cover)
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create training %w", err)
+	}
+
+	savedTraining, err := c.trainingRepository.Save(training)
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to save training: %w", err)
+	}
+
+	return savedTraining, nil
+}

--- a/internal/application/usecase/get_all_training_usecase.go
+++ b/internal/application/usecase/get_all_training_usecase.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"fmt"
+
 	"github.com/squillteam/powerflix-backend/internal/application/port/input"
 	"github.com/squillteam/powerflix-backend/internal/application/port/output"
 	"github.com/squillteam/powerflix-backend/internal/domain/entity"
@@ -16,8 +18,12 @@ func NewTrainingUseCase(trainingRepo output.TrainingRepository) input.GetAllTrai
 	}
 }
 
-func (this trainingUseCaseImpl) Execute() ([]entity.Training, error) {
-	this.trainingRepo.GetAllTraining()
+func (u trainingUseCaseImpl) Execute() ([]*entity.Training, error) {
+	trainings, err := u.trainingRepo.GetAll()
 
-	return nil, nil
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get all trainings: %w", err)
+	}
+
+	return trainings, nil
 }

--- a/internal/domain/entity/training.go
+++ b/internal/domain/entity/training.go
@@ -1,8 +1,42 @@
 package entity
 
+import (
+	"errors"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrNameTooShort     = errors.New("Name must be at least 3 characters long")
+	ErrEmptyDescription = errors.New("Description cannot be empty")
+	ErrEmptyCover       = errors.New("Cover cannot be empty")
+)
+
 type Training struct {
-	ID          string
+	ID          uuid.UUID
 	Name        string
 	Description string
 	Cover       string
+}
+
+func NewTraining(name, description, cover string) (*Training, error) {
+	if name == "" || utf8.RuneCountInString(name) < 3 {
+		return nil, ErrNameTooShort
+	}
+
+	if description == "" {
+		return nil, ErrEmptyDescription
+	}
+
+	if cover == "" {
+		return nil, ErrEmptyCover
+	}
+
+	return &Training{
+		ID:          uuid.New(),
+		Name:        name,
+		Description: description,
+		Cover:       cover,
+	}, nil
 }

--- a/internal/infrastructure/adapter/output/persistence/memory_training_repository.go
+++ b/internal/infrastructure/adapter/output/persistence/memory_training_repository.go
@@ -1,0 +1,40 @@
+package persistence
+
+import (
+	"sync"
+
+	"github.com/squillteam/powerflix-backend/internal/application/port/output"
+	"github.com/squillteam/powerflix-backend/internal/domain/entity"
+)
+
+type MemoryTrainingRepository struct {
+	trainings []*entity.Training
+	mu        sync.RWMutex
+}
+
+func NewMemoryTrainingRepository() output.TrainingRepository {
+	return &MemoryTrainingRepository{
+		trainings: []*entity.Training{},
+	}
+}
+
+func (r *MemoryTrainingRepository) Save(training *entity.Training) (*entity.Training, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.trainings = append(r.trainings, training)
+
+	return training, nil
+}
+
+func (r *MemoryTrainingRepository) GetAll() ([]*entity.Training, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*entity.Training, 0, len(r.trainings))
+	for _, trainingPtr := range r.trainings {
+		result = append(result, trainingPtr)
+	}
+
+	return result, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,20 +1,28 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"github.com/squillteam/powerflix-backend/internal/domain/entity"
+	"github.com/squillteam/powerflix-backend/internal/application/usecase"
+	"github.com/squillteam/powerflix-backend/internal/infrastructure/adapter/output/persistence"
 )
 
 func main() {
-	fmt.Println("Hello World!")
+	repo := persistence.NewMemoryTrainingRepository()
+	trainingUseCase := usecase.NewTrainingUseCase(repo)
 
-	training := entity.Training{
-		ID:          "1",
-		Name:        "Arnold Biceps",
-		Description: "Anorld Biceps from hell",
-		Cover:       "https://example.com/cover.jpg",
+	trainings, err := trainingUseCase.Execute()
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
 	}
 
-	fmt.Printf("%+v\n", training)
+	jsonData, err := json.MarshalIndent(trainings, "", " ")
+	if err != nil {
+		fmt.Println("Error converting to JSON:", err)
+		return
+	}
+
+	fmt.Println(string(jsonData))
 }


### PR DESCRIPTION
* chore: add infra directories and memory persistence file

* feat: implement in-memory training repository

* fix: GetAllTrainings execution logic

* test: integrate and test training use case flow

* refactor: add thread-safety with RWMutex

* Update internal/infrastructure/adapter/output/persistence/memory_training_repository.go



* Update internal/infrastructure/adapter/output/persistence/memory_training_repository.go



* feat: create Save method

* Update internal/application/usecase/create_training_usecase.go



* Update internal/infrastructure/adapter/output/persistence/memory_training_repository.go



* Update internal/application/usecase/create_training_usecase.go



* feat: add UUID generation for Training entities

* refactor: improve error handling with context

* feat: validate Training fields with custom errors

---------